### PR TITLE
Set timelapse pics names from gcode filename

### DIFF
--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -132,7 +132,7 @@ class Snapshot:
 
         return True
 
-    def _get_latest_file_number(save_directory: str, base_name: str) -> int:
+    def _get_latest_file_number(self, save_directory: str, base_name: str) -> int:
         """ Get latest file number from saved files in the directory """
         files = sorted(Path(save_directory).glob(f"{base_name}_*.jpg"))
 

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -100,9 +100,6 @@ class Snapshot:
 
         if not file_base_name:
             file_base_name = os.path.basename(save_directory)
-            log.warning(f"Using default basename ({file_base_name})")
-        else:
-            log.warning(f"Basename was provided: {file_base_name}")
 
         if not self._check_directory_limits(save_directory):
             log.error("Directory exceeds file or size limits.")

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -100,6 +100,9 @@ class Snapshot:
 
         if not file_base_name:
             file_base_name = os.path.basename(save_directory)
+            log.warning(f"Using default basename ({file_base_name})")
+        else:
+            log.warning(f"Basename was provided: {file_base_name}")
 
         if not self._check_directory_limits(save_directory):
             log.error("Directory exceeds file or size limits.")

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -58,6 +58,7 @@ class Snapshot:
         """Is this snapshot part of the layer change shots?"""
         required_attributes = [
             self.camera_token,
+            # TODO: M3D-7: Identify why this is not available during saving
             # self.camera_id,
             self.timestamp,
             self.data,
@@ -102,7 +103,7 @@ class Snapshot:
             file_base_name = os.path.basename(save_directory)
 
         if not self._check_directory_limits(save_directory):
-            log.error("Directory exceeds file or size limits.")
+            log.error("Directory exceeds file or size limits. (Dir -> %s)", save_directory)
             return
 
         latest_file_number = self._get_latest_file_number(save_directory, file_base_name)
@@ -117,7 +118,7 @@ class Snapshot:
     def _check_directory_limits(self, directory: str) -> bool:
         """Check if the directory exceeds file or size limits"""
         file_limit = 1200
-        size_limit_bytes = 250 * 1024 * 1024
+        size_limit_bytes = 450 * 1024 * 1024
 
         file_count = 0
         total_size = 0

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -41,7 +41,7 @@ class Snapshot:
         self.printer_uuid = None
         self.data = None
         self.timestamp = None
-        self.on_layer_change = False
+        self.on_layer_change = None
 
     def is_sendable(self) -> bool:
         """Is this snapshot complete and can it therefore be sent?"""

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -58,7 +58,7 @@ class Snapshot:
         """Is this snapshot part of the layer change shots?"""
         required_attributes = [
             self.camera_token,
-            self.camera_id,
+            # self.camera_id,
             self.timestamp,
             self.data,
             self.on_layer_change,

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -174,9 +174,12 @@ class CameraController:
         """Puts a snapshot received from the callback into a queue
         for sending and/or saving for a timelapse"""
         if snapshot.is_timelapse():
+            log.error("Enqueuing the shot to the TIMELAPSE queue")
             self.timelapse_queue.put(snapshot)
-        elif snapshot.is_sendable():
-            self.snapshot_queue.put(snapshot)
+        if not snapshot.is_sendable():
+            return
+        log.error("Enqueuing the shot to the CONNECT queue")
+        self.snapshot_queue.put(snapshot)
 
     def snapshot_loop(self) -> None:
         """Gets an item Snapshot from queue and sends it"""

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -42,6 +42,8 @@ class CameraController:
         self.snapshot_queue: Queue[Snapshot] = Queue()
         self.timelapse_queue: Queue[Snapshot] = Queue()
 
+        self.timelapse_name: str = "no_name"
+
         self._cameras: Dict[str, Camera] = {}
         self._camera_order: List[str] = []
         self._trigger_piles: Dict[TriggerScheme, Set[Camera]] = {
@@ -104,6 +106,10 @@ class CameraController:
         for camera_id in self._camera_order:
             if camera_id in self._cameras:
                 yield self._cameras[camera_id]
+
+    def set_timelapse_name(self, name: str = "test_timelapse") -> None:
+        """Define the current timelapse file base name"""
+        self.timelapse_name = name
 
     def set_camera_order(self, camera_order: List[str]) -> None:
         """Usually called by the CameraConfigurator to order
@@ -217,7 +223,7 @@ class CameraController:
                 # TODO: Find a way to get the file_base_name from the print filename.
                 #       Maybe using print_stats.get_stats() in Prusa-Link and send it
                 #       somehow to this scope.
-                item.save(os.path.join(Path.home(), "prusa/timelapses"), "test_timelapse")
+                item.save(os.path.join(Path.home(), "prusa/timelapses"), self.timelapse_name)
             except Empty:
                 continue
             except Exception:  # pylint: disable=broad-except

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -220,10 +220,7 @@ class CameraController:
                 item = self.timelapse_queue.get(timeout=TIMESTAMP_PRECISION)
 
                 # Save it
-                # TODO: Find a way to get the file_base_name from the print filename.
-                #       Maybe using print_stats.get_stats() in Prusa-Link and send it
-                #       somehow to this scope.
-                item.save(os.path.join(Path.home(), "prusa/timelapses"), self.timelapse_name)
+                item.save(os.path.join(Path.home(), "prusa/timelapses", self.timelapse_name))
             except Empty:
                 continue
             except Exception:  # pylint: disable=broad-except

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -42,7 +42,7 @@ class CameraController:
         self.snapshot_queue: Queue[Snapshot] = Queue()
         self.timelapse_queue: Queue[Snapshot] = Queue()
 
-        self.timelapse_name: str = "no_name"
+        self.timelapse_name = "no_name"
 
         self._cameras: Dict[str, Camera] = {}
         self._camera_order: List[str] = []
@@ -109,7 +109,12 @@ class CameraController:
 
     def set_timelapse_name(self, name: str = "test_timelapse") -> None:
         """Define the current timelapse file base name"""
+        log.warning("Setting timelapse name to %s", name)
         self.timelapse_name = name
+
+    def get_timelapse_name(self) -> str:
+        """Define the current timelapse file base name"""
+        return self.timelapse_name
 
     def set_camera_order(self, camera_order: List[str]) -> None:
         """Usually called by the CameraConfigurator to order
@@ -149,6 +154,7 @@ class CameraController:
                 timelapse_snap = Snapshot()
                 timelapse_snap.on_layer_change = True
                 camera.trigger_a_photo(snapshot=timelapse_snap)
+                log.warning("Triggering a timelapse photo for %s", self.timelapse_name)
             except CameraBusy:
                 log.warning("Skipping timelapse shot from camera %s because it's busy",
                             camera.name)
@@ -180,8 +186,14 @@ class CameraController:
         """Puts a snapshot received from the callback into a queue
         for sending and/or saving for a timelapse"""
         if snapshot.is_timelapse():
-            log.error("Enqueuing the shot to the TIMELAPSE queue")
             self.timelapse_queue.put(snapshot)
+            log.warning("Enqueuing the shot to the TIMELAPSE queue (name = %s)", self.timelapse_name)
+        else:
+            log.warning("camera_token -> %d", snapshot.camera_token is None)
+            log.warning("camera_id -> %d", snapshot.camera_id is None)
+            log.warning("timestamp -> %d", snapshot.timestamp is None)
+            log.warning("data -> %d", snapshot.data is None)
+            log.warning("on_layer_change -> %d", snapshot.on_layer_change is None)
         if not snapshot.is_sendable():
             return
         log.error("Enqueuing the shot to the CONNECT queue")
@@ -218,6 +230,10 @@ class CameraController:
             try:
                 # Get the item to send
                 item = self.timelapse_queue.get(timeout=TIMESTAMP_PRECISION)
+
+                if item:
+                    log.warning("Saving snap into %s with the name of %s.",
+                        os.path.join(Path.home(), 'prusa/timelapses'), self.timelapse_name)
 
                 # Save it
                 # TODO: Find a way to get the file_base_name from the print filename.

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -135,6 +135,18 @@ class CameraController:
             self.trigger_pile(TriggerScheme.FIFTH_LAYER)
             self._layer_trigger_counter = 0
 
+    def timestamp_shot_trigger(self, camera_idx: int = 0) -> None:
+        """ Triggers a photo on the first listed camera """
+        camera = list(self.cameras_in_order)[camera_idx]
+        if camera:
+            try:
+                timelapse_snap = Snapshot()
+                timelapse_snap.on_layer_change = True
+                camera.trigger_a_photo(snapshot=timelapse_snap)
+            except CameraBusy:
+                log.warning("Skipping timelapse shot from camera %s because it's busy",
+                            camera.name)
+
     def tick(self) -> None:
         """Called periodically by the SDK to let us trigger cameras when it's
         the right time"""


### PR DESCRIPTION
Instead of storing all timelapses in ascending order on a hardcoded directory, use the gcode filename as the directory name and store every snapshot in that directory with the same ascending mechanism order.
```terminal
~/prusa/
└─ timelapses
     ├─ TEST_0001.jpg
     ├─ TEST_0002.jpg
     ├─ TEST_0003.jpg
     └─ ...
```