### PR TITLE
M3D-4: Take picture on actual layer change

### DIFF
--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -132,7 +132,7 @@ class Snapshot:
 
         return True
 
-    def _get_latest_file_number(save_directory: str, base_name: str) -> int:
+    def _get_latest_file_number(self, save_directory: str, base_name: str) -> int:
         """ Get latest file number from saved files in the directory """
         files = sorted(Path(save_directory).glob(f"{base_name}_*.jpg"))
 

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -41,7 +41,7 @@ class Snapshot:
         self.printer_uuid = None
         self.data = None
         self.timestamp = None
-        self.on_layer_change = False
+        self.on_layer_change = None
 
     def is_sendable(self) -> bool:
         """Is this snapshot complete and can it therefore be sent?"""

--- a/prusa/connect/printer/camera.py
+++ b/prusa/connect/printer/camera.py
@@ -57,7 +57,6 @@ class Snapshot:
     def is_timelapse(self) -> bool:
         """Is this snapshot part of the layer change shots?"""
         required_attributes = [
-            self.camera_token,
             self.camera_id,
             self.timestamp,
             self.data,

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -142,6 +142,7 @@ class CameraController:
             try:
                 timelapse_snap = Snapshot()
                 timelapse_snap.on_layer_change = True
+                timelapse_snap.camera_id = camera.camera_id
                 camera.trigger_a_photo(snapshot=timelapse_snap)
             except CameraBusy:
                 log.warning("Skipping timelapse shot from camera %s because it's busy",
@@ -174,11 +175,9 @@ class CameraController:
         """Puts a snapshot received from the callback into a queue
         for sending and/or saving for a timelapse"""
         if snapshot.is_timelapse():
-            log.error("Enqueuing the shot to the TIMELAPSE queue")
             self.timelapse_queue.put(snapshot)
         if not snapshot.is_sendable():
             return
-        log.error("Enqueuing the shot to the CONNECT queue")
         self.snapshot_queue.put(snapshot)
 
     def snapshot_loop(self) -> None:

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -174,9 +174,12 @@ class CameraController:
         """Puts a snapshot received from the callback into a queue
         for sending and/or saving for a timelapse"""
         if snapshot.is_timelapse():
+            log.error("Enqueuing the shot to the TIMELAPSE queue")
             self.timelapse_queue.put(snapshot)
-        elif snapshot.is_sendable():
-            self.snapshot_queue.put(snapshot)
+        if not snapshot.is_sendable():
+            return
+        log.error("Enqueuing the shot to the CONNECT queue")
+        self.snapshot_queue.put(snapshot)
 
     def snapshot_loop(self) -> None:
         """Gets an item Snapshot from queue and sends it"""

--- a/prusa/connect/printer/camera_controller.py
+++ b/prusa/connect/printer/camera_controller.py
@@ -135,6 +135,18 @@ class CameraController:
             self.trigger_pile(TriggerScheme.FIFTH_LAYER)
             self._layer_trigger_counter = 0
 
+    def timestamp_shot_trigger(self, camera_idx: int = 0) -> None:
+        """ Triggers a photo on the first listed camera """
+        camera = list(self.cameras_in_order)[camera_idx]
+        if camera:
+            try:
+                timelapse_snap = Snapshot()
+                timelapse_snap.on_layer_change = True
+                camera.trigger_a_photo(snapshot=timelapse_snap)
+            except CameraBusy:
+                log.warning("Skipping timelapse shot from camera %s because it's busy",
+                            camera.name)
+
     def tick(self) -> None:
         """Called periodically by the SDK to let us trigger cameras when it's
         the right time"""


### PR DESCRIPTION
> This is the enabling part of https://github.com/Magdiel3/Prusa-Link/pull/1

Added a `save()` action for sanpshots so that specifcially triggered ohtotos could be saved into a directory for later to be converted into a timelapse. More details on associated PR.